### PR TITLE
🔧 Disambiguate HTTP response code

### DIFF
--- a/src/main/java/shared/Helpers.java
+++ b/src/main/java/shared/Helpers.java
@@ -20,7 +20,13 @@ public class Helpers {
 
     public static void sendJSON(ChannelHandlerContext channelHandlerContext, JSONObject jsonObject) {
         ByteBuf content = Unpooled.copiedBuffer(jsonObject.toString(), CharsetUtil.UTF_8);
-        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, content);
+        FullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1,
+                jsonObject.get("error") == JSONObject.NULL
+                        ? HttpResponseStatus.OK
+                        : HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                content
+        );
         response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json");
         response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, content.readableBytes());
         channelHandlerContext.writeAndFlush(response);


### PR DESCRIPTION
Make a binary _(for now)_ distinction between a successful & a failed HTTP request by making the HTTP response code dependent on the nature of the response's payload.

• <b>200 <i>OK</i></b>
```js
{
    "data": {
        ...
    },
    "error": null
}
```

• <b>500 <i>Internal Server Error</i></b>
```js
{
    "data": null,
    "error": {
        ...
    }
}
```